### PR TITLE
feat: add openrazer-daemon-only package

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,16 @@ mv tmp/openrazer-daemon/resources/org.razer.service.in tmp/openrazer-daemon/reso
 mv tmp/openrazer-daemon/resources/openrazer-daemon.systemd.service.in tmp/openrazer-daemon/resources/openrazer-daemon.service
 tar -czvf rpmbuild/SOURCES/openrazer-daemon.tar.gz -C tmp openrazer-daemon
 
+mkdir tmp/openrazer-daemon-only
+cp -r src/daemon/* tmp/openrazer-daemon-only
+rm tmp/openrazer-daemon-only/Makefile
+rm -r tmp/openrazer-daemon-only/tests
+sed -i "s|##PREFIX##|/usr|" tmp/openrazer-daemon-only/resources/org.razer.service.in \
+    tmp/openrazer-daemon-only/resources/openrazer-daemon.systemd.service.in
+mv tmp/openrazer-daemon-only/resources/org.razer.service.in tmp/openrazer-daemon-only/resources/org.razer.service
+mv tmp/openrazer-daemon-only/resources/openrazer-daemon.systemd.service.in tmp/openrazer-daemon-only/resources/openrazer-daemon.service
+tar -czvf rpmbuild/SOURCES/openrazer-daemon-only.tar.gz -C tmp openrazer-daemon-only
+
 mkdir tmp/python-openrazer
 cp -r src/pylib/* tmp/python-openrazer
 rm -r tmp/python-openrazer/tests
@@ -34,6 +44,7 @@ sed -i "s/RELEASE_VERSION/${RELEASE_VERSION:-1}/" rpmbuild/SPECS/*
 rpmbuild -ba --define "_topdir ${PWD}/rpmbuild" rpmbuild/SPECS/openrazer-kmod.spec
 rpmbuild -ba --define "_topdir ${PWD}/rpmbuild" rpmbuild/SPECS/openrazer.spec
 rpmbuild -ba --define "_topdir ${PWD}/rpmbuild" rpmbuild/SPECS/openrazer-daemon.spec
+rpmbuild -ba --define "_topdir ${PWD}/rpmbuild" rpmbuild/SPECS/openrazer-daemon-only.spec
 rpmbuild -ba --define "_topdir ${PWD}/rpmbuild" rpmbuild/SPECS/python-openrazer.spec
 
 rm -vf out/*.rpm

--- a/openrazer-daemon-only.spec
+++ b/openrazer-daemon-only.spec
@@ -1,0 +1,60 @@
+%global debug_package %{nil}
+
+Name:           openrazer-daemon-only
+Version:        OPENRAZER_VERSION
+Release:        RELEASE_VERSION%{?dist}
+Summary:        Openrazer daemon
+License:        GPL-2.0
+URL:            https://github.com/openrazer/openrazer
+Source0:        openrazer-daemon.tar.gz
+
+Provides:       openrazer-daemon = %{version}
+
+BuildArch:      noarch
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  systemd-rpm-macros
+
+%description
+Openrazer daemon that adds persistence support and more. daemon only.
+
+%prep
+%setup -n openrazer-daemon
+
+%build
+%py3_build
+
+%install
+rm -rf %{buildroot}
+%py3_install
+install -v -D -m 644 resources/razer.conf                   %{buildroot}/%{_datadir}/openrazer/razer.conf.example
+install -v -D -m 755 run_openrazer_daemon.py                %{buildroot}/%{_bindir}/openrazer-daemon
+install -v -D -m 644 resources/org.razer.service            %{buildroot}/%{_datadir}/dbus-1/services/org.razer.service
+install -v -D -m 644 resources/openrazer-daemon.service     %{buildroot}/%{_userunitdir}/openrazer-daemon.service
+
+%clean
+rm -rf %{buildroot}
+
+%post
+%systemd_user_post openrazer-daemon.service
+
+%preun
+%systemd_user_preun openrazer-daemon.service
+
+%postun
+%systemd_user_postun_with_restart openrazer-daemon.service
+
+%files
+%{python3_sitelib}/openrazer_daemon/
+%{python3_sitelib}/openrazer_daemon-*.egg-info/
+
+%doc resources/man/razer.conf.5
+%doc resources/man/openrazer-daemon.8
+%config %{_datadir}/openrazer/razer.conf.example
+
+%{_bindir}/openrazer-daemon
+%{_datadir}/dbus-1/services/org.razer.service
+%{_userunitdir}/openrazer-daemon.service
+
+%changelog
+%autochangelog


### PR DESCRIPTION
this pr will add openrazer-daemon without depends on openrazer-kmod, useful for building systemd-sysext package since it doesn't pull openrazer-kmod package which important for systemd system extensions.